### PR TITLE
Change main branch to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- **BREAKING** Default branch is now assumed to be `main` rather than `master`. ([#13](https://github.com/diffplug/spotless-changelog/pull/13))
 ### Fixed
 - Better error message for cases where the `spotlessChangelog` block is too low. ([#6](https://github.com/diffplug/spotless-changelog/issues/6))
 - Bug in `PoolString.concat(String)` ([1f6da65](https://github.com/diffplug/spotless-changelog/commit/1f6da65b51c5ee7af847dc0e427fe685fbd3d43c)).

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ We also support other version schemas, like `2.0` instead of `2.0.0`, or `brand.
 
 The terrible thing about `0.x` is that *the more unstable a codebase is, the more valuable **(concise compatibility guarantee).(new feature advertisement).(lowest downside risk to upgrade)** would be!*
 
-But habits are what they are, and you're going to keep publishing things with `0.x`.  I will judge you for that, but Spotless Changelog won't.  It will just increment the `added` version (`0.1.0`, `0.2.0`, `0.3.0`, etc) whether your changelog has `**BREAKING**` or just `### Added`.  See how the information is getting lost?  If you really want to stick with `0.x`, you can convey a lot more information with [`0.breaking.added.fixed`](https://github.com/diffplug/spotless-changelog/blob/master/ALTERNATE_VERSION_SCHEMAS.md#available-schemas).
+But habits are what they are, and you're going to keep publishing things with `0.x`.  I will judge you for that, but Spotless Changelog won't.  It will just increment the `added` version (`0.1.0`, `0.2.0`, `0.3.0`, etc) whether your changelog has `**BREAKING**` or just `### Added`.  See how the information is getting lost?  If you really want to stick with `0.x`, you can convey a lot more information with [`0.breaking.added.fixed`](https://github.com/diffplug/spotless-changelog/blob/main/ALTERNATE_VERSION_SCHEMAS.md#available-schemas).
 
 ### Alphas, betas, release-candidates, etc.
 
@@ -128,11 +128,11 @@ spotlessChangelog {  // defaults
   tagPrefix 'release/'
   commitMessage 'Published release/{{version}}' // {{version}} will be replaced
   remote 'origin'
-  branch 'master'
+  branch 'main'
 }
 ```
 
-We recommend that you use `changelogPush` as your deploy task, and wire your tasks so that it will only happen if the publish was successful.  Here is a [battle-tested wiring plan](https://github.com/diffplug/blowdryer-diffplug/blob/master/src/main/resources/base/changelog.gradle) which can even [update your README.md with the latest version number](https://github.com/diffplug/blowdryer-diffplug/blob/2.0.0/src/main/resources/spotless/freshmark.gradle#L35-L61).  A simpler scheme is presented below:
+We recommend that you use `changelogPush` as your deploy task, and wire your tasks so that it will only happen if the publish was successful.  Here is a [battle-tested wiring plan](https://github.com/diffplug/blowdryer-diffplug/blob/main/src/main/resources/base/changelog.gradle) which can even [update your README.md with the latest version number](https://github.com/diffplug/blowdryer-diffplug/blob/2.0.0/src/main/resources/spotless/freshmark.gradle#L35-L61).  A simpler scheme is presented below:
 
 ### Multiple changelogs per project
 
@@ -172,7 +172,7 @@ spotlessChangelog { // all defaults
   tagPrefix 'release/'
   commitMessage 'Published release/{version}' // {version} will be replaced
   remote 'origin'
-  branch 'master'
+  branch 'main'
 }
 
 // last version parsed from changelog

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
@@ -28,7 +28,7 @@ public class GitCfg {
 	/** Message used for release commits, default is `Published release/{{version}}`. */
 	public String commitMessage = "Published release/" + COMMIT_MESSAGE_VERSION;
 	public String remote = "origin";
-	public String branch = "master";
+	public String branch = "main";
 
 	/** Returns an api configured with this config. */
 	public GitActions withChangelog(File changelogFile, ChangelogAndNext model) throws IOException {

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -112,7 +112,7 @@ public class ChangelogExtension {
 	/**
 	 * Sets a custom {@link NextVersionFunction} by calling the public no-arg constructor of the given class.
 	 * Default value is {@link com.diffplug.spotless.changelog.NextVersionFunction.Semver Semver}.
-	 * See [ALTERNATE_VERSION_SCHEMAS.md](https://github.com/diffplug/spotless-changelog/blob/master/ALTERNATE_VERSION_SCHEMAS.md) for more info.
+	 * See [ALTERNATE_VERSION_SCHEMAS.md](https://github.com/diffplug/spotless-changelog/blob/main/ALTERNATE_VERSION_SCHEMAS.md) for more info.
 	 */
 	public void versionSchema(Class<? extends NextVersionFunction> functionClass) throws InstantiationException, IllegalAccessException {
 		assertNotCalculatedYet();
@@ -188,7 +188,7 @@ public class ChangelogExtension {
 		gitCfg.remote = remote;
 	}
 
-	/** Default value is 'master' */
+	/** Default value is 'main' */
 	public void branch(String branch) {
 		gitCfg.branch = branch;
 	}


### PR DESCRIPTION
Once this PR has been merged, `main` will be our main branch, rather than `master`.

We have many links to our documentation out in the wild, such as: https://github.com/diffplug/spotless-changelog/blob/master/README.md#keep-your-changelog-clean

Preserving the history of these links is an absolute must. For now, I will manually keep it parallel with main, and I'll happily help anyone migrate any PRs against the deprecated master to their new home at main. Eventually I plan to build a tool to create an orphan commit at master which replaces every .md file, including anchors, with a link to the appropriately anchored place at our new main branch.