### PR TITLE
add an option to create annotated tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `tagMessage` allows to create annotated tags when publishing new versions. ([#22](https://github.com/diffplug/spotless-changelog/pull/22))
 
 ## [2.1.2] - 2021-04-10
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ spotlessChangelog { // all defaults
   // keep changelog formatted
   changelogFile 'CHANGELOG.md'
   enforceCheck true
+  annotateTags false  
   // calculate next version (breaking.added.fixed)
   ifFoundBumpBreaking ['**BREAKING**']
   ifFoundBumpAdded    ['### Added']

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ spotlessChangelog { // all defaults
   // tag and push
   tagPrefix 'release/'
   commitMessage 'Published release/{{version}}' // {{version}} will be replaced
-  annotateMessage '' // default is empty string (creates lightweight tag); {{version}} will be replaced
+  tagMessage '' // default is empty string (creates lightweight tag); {{version}} will be replaced
   remote 'origin'
   branch 'main'
   // default value is `yes`, but if you set it to `no`, then it will

--- a/README.md
+++ b/README.md
@@ -159,7 +159,6 @@ spotlessChangelog { // all defaults
   // keep changelog formatted
   changelogFile 'CHANGELOG.md'
   enforceCheck true
-  annotateTags false  
   // calculate next version (breaking.added.fixed)
   ifFoundBumpBreaking ['**BREAKING**']
   ifFoundBumpAdded    ['### Added']
@@ -172,6 +171,7 @@ spotlessChangelog { // all defaults
   // tag and push
   tagPrefix 'release/'
   commitMessage 'Published release/{{version}}' // {{version}} will be replaced
+  annotateMessage '' // default is empty string (creates lightweight tag); {{version}} will be replaced
   remote 'origin'
   branch 'main'
   // default value is `yes`, but if you set it to `no`, then it will

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ spotlessChangelog { // all defaults
   // tag and push
   tagPrefix 'release/'
   commitMessage 'Published release/{{version}}' // {{version}} will be replaced
-  tagMessage '' // default is empty string (creates lightweight tag); {{version}} will be replaced
+  tagMessage null // default is null (creates lightweight tag); {{changes}} and {{version}} will be replaced
   remote 'origin'
   branch 'main'
   // default value is `yes`, but if you set it to `no`, then it will

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
@@ -140,19 +140,6 @@ public class Changelog {
 		return unreleasedChanges().replace("\n", "").trim().isEmpty();
 	}
 
-	private static final int LAST_RELEASE = 1;
-
-	/** Returns the string describing changes in last released version - either empty, or starts with a newline, and has unix newlines. */
-	public String lastReleasedChanges() {
-		if (versionsRaw.isEmpty()) {
-			return "";
-		}
-		if (versionsRaw.get(LAST_RELEASE).changes != null) {
-			return versionsRaw.get(LAST_RELEASE).changes.toString();
-		}
-		return "";
-	}
-
 	private void addError(int lineNumber, String message) {
 		parseErrors.put(lineNumber, message);
 	}

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
@@ -165,6 +165,15 @@ public class Changelog {
 
 		private VersionEntry() {}
 
+		private VersionEntry copy() {
+			VersionEntry copy = new VersionEntry();
+			copy.version = version;
+			copy.date = date;
+			copy.headerMisc = headerMisc;
+			copy.changes = changes;
+			return copy;
+		}
+
 		/** Creates a VersionHeader of the given version and date. */
 		public static VersionEntry versionDate(String version, String date) {
 			VersionEntry header = new VersionEntry();
@@ -292,6 +301,11 @@ public class Changelog {
 				return PoolString.concat("\n## [", version, "] - ", date, " ", headerMisc, changes);
 			}
 		}
+
+		@Override
+		public String toString() {
+			return version + "xxxxxxw " + changes.toString().replaceAll(" |\n", "");
+		}
 	}
 
 	/** Returns a ParsedChangelog where the version list has been mutated by the given mutator. */
@@ -307,7 +321,7 @@ public class Changelog {
 	/** Returns a new changelog where the [Unreleased] section has been released with the given version and date. */
 	public Changelog releaseUnreleased(String version, String date) {
 		return withMutatedVersions(list -> {
-			VersionEntry unreleased = list.get(0);
+			VersionEntry unreleased = list.get(0).copy();
 			Preconditions.checkArgument(unreleased.isUnreleased());
 
 			VersionEntry entry = VersionEntry.versionDate(version, date);

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
@@ -35,8 +35,6 @@ public class Changelog {
 	private static final String VERSION_BEGIN = "\n## [";
 	private static final String UNRELEASED = VERSION_BEGIN + "Unreleased]";
 	private static final String DONT_PARSE_BELOW_HERE = "\n<!-- END CHANGELOG -->";
-	public static final int LAST_RELEASE = 1;
-
 	private final boolean windowsNewlines;
 	private final PoolString dontParse, beforeUnreleased;
 	private final List<VersionEntry> versionsRaw;
@@ -142,7 +140,9 @@ public class Changelog {
 		return unreleasedChanges().replace("\n", "").trim().isEmpty();
 	}
 
-	/** Returns the string describing changes in last released version - starts with a newline, and has unix newlines. */
+	private static final int LAST_RELEASE = 1;
+
+	/** Returns the string describing changes in last released version - either empty, or starts with a newline, and has unix newlines. */
 	public String lastReleasedChanges() {
 		if (versionsRaw.isEmpty()) {
 			return "";

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
@@ -301,11 +301,6 @@ public class Changelog {
 				return PoolString.concat("\n## [", version, "] - ", date, " ", headerMisc, changes);
 			}
 		}
-
-		@Override
-		public String toString() {
-			return version + "xxxxxxw " + changes.toString().replaceAll(" |\n", "");
-		}
 	}
 
 	/** Returns a ParsedChangelog where the version list has been mutated by the given mutator. */

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 DiffPlug
+ * Copyright (C) 2019-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ public class Changelog {
 	private static final String VERSION_BEGIN = "\n## [";
 	private static final String UNRELEASED = VERSION_BEGIN + "Unreleased]";
 	private static final String DONT_PARSE_BELOW_HERE = "\n<!-- END CHANGELOG -->";
+	public static final int LAST_RELEASE = 1;
 
 	private final boolean windowsNewlines;
 	private final PoolString dontParse, beforeUnreleased;
@@ -139,6 +140,17 @@ public class Changelog {
 	/** Returns true if there are no unreleased changes. */
 	public boolean noUnreleasedChanges() {
 		return unreleasedChanges().replace("\n", "").trim().isEmpty();
+	}
+
+	/** Returns the string describing changes in last released version - starts with a newline, and has unix newlines. */
+	public String lastReleasedChanges() {
+		if (versionsRaw.isEmpty()) {
+			return "";
+		}
+		if (versionsRaw.get(LAST_RELEASE).changes != null) {
+			return versionsRaw.get(LAST_RELEASE).changes.toString();
+		}
+		return "";
 	}
 
 	private void addError(int lineNumber, String message) {

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/Changelog.java
@@ -316,12 +316,13 @@ public class Changelog {
 	/** Returns a new changelog where the [Unreleased] section has been released with the given version and date. */
 	public Changelog releaseUnreleased(String version, String date) {
 		return withMutatedVersions(list -> {
-			VersionEntry unreleased = list.get(0).copy();
+			VersionEntry unreleased = list.get(0);
 			Preconditions.checkArgument(unreleased.isUnreleased());
 
 			VersionEntry entry = VersionEntry.versionDate(version, date);
 			entry.setChanges(unreleased.changes());
-			unreleased.setChanges("\n");
+
+			list.set(0, unreleased.copy().setChanges("\n"));
 			list.add(1, entry);
 		});
 	}

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/ChangelogAndNext.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/ChangelogAndNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 DiffPlug
+ * Copyright (C) 2019-2020 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,10 +101,6 @@ public class ChangelogAndNext {
 
 	public Versions versions() {
 		return versions;
-	}
-
-	public String changes() {
-		return changelog().lastReleasedChanges();
 	}
 
 	/** The next and previously published versions. */

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/ChangelogAndNext.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/ChangelogAndNext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2020 DiffPlug
+ * Copyright (C) 2019-2021 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,6 +101,10 @@ public class ChangelogAndNext {
 
 	public Versions versions() {
 		return versions;
+	}
+
+	public String changes() {
+		return changelog().lastReleasedChanges();
 	}
 
 	/** The next and previously published versions. */

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
@@ -99,8 +99,8 @@ public class GitActions implements AutoCloseable {
 	/** Tags and pushes the tag and the branch.  */
 	public void tagBranchPush() throws GitAPIException {
 		TagCommand tagCommand = git.tag().setName(tagName());
-		if (cfg.useAnnotatedTag()) {
-			tagCommand.setAnnotated(true).setMessage(formatTagMessage(cfg.tagMessage()));
+		if (cfg.tagMessage != null) {
+			tagCommand.setAnnotated(true).setMessage(formatTagMessage(cfg.tagMessage));
 		}
 		push(tagCommand.call(), RemoteRefUpdate.Status.OK);
 		push(cfg.branch, RemoteRefUpdate.Status.OK);
@@ -112,7 +112,8 @@ public class GitActions implements AutoCloseable {
 
 	private String formatTagMessage(final String tagMessage) {
 		return formatCommitMessage(tagMessage)
-				.replace(GitCfg.TAG_MESSAGE_CHANGES, model.changelog().unreleasedChanges());
+				.replace(GitCfg.TAG_MESSAGE_CHANGES, model.changelog().unreleasedChanges())
+				.replace(GitCfg.COMMIT_MESSAGE_VERSION, model.versions().next());
 	}
 
 	private String tagName() {

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
@@ -97,9 +97,10 @@ public class GitActions implements AutoCloseable {
 				.call();
 	}
 
-	/** Tags and pushes the tag and the branch. */
-	public void tagBranchPush() throws GitAPIException {
-		Ref tagRef = git.tag().setName(tagName()).setAnnotated(false).call();
+	/** Tags and pushes the tag and the branch.
+	 * @param annotated false for lightweight tags, true for annotated tags */
+	public void tagBranchPush(final boolean annotated) throws GitAPIException {
+		Ref tagRef = git.tag().setName(tagName()).setAnnotated(annotated).call();
 		push(tagRef, RemoteRefUpdate.Status.OK);
 		push(cfg.branch, RemoteRefUpdate.Status.OK);
 	}

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
@@ -112,7 +112,7 @@ public class GitActions implements AutoCloseable {
 
 	private String formatTagMessage(final String tagMessage) {
 		return formatCommitMessage(tagMessage)
-				.replace(GitCfg.TAG_MESSAGE_CHANGES, model.changelog().lastReleasedChanges());
+				.replace(GitCfg.TAG_MESSAGE_CHANGES, model.changelog().unreleasedChanges());
 	}
 
 	private String tagName() {

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
@@ -55,11 +55,9 @@ public class GitActions implements AutoCloseable {
 		this.changelogFile = changelogFile;
 		this.model = model;
 		this.cfg = cfg;
-		final FileRepositoryBuilder fileRepositoryBuilder = new FileRepositoryBuilder();
-		repository = fileRepositoryBuilder
+		repository = new FileRepositoryBuilder()
 				.findGitDir(changelogFile)
 				.build();
-		repository.getWorkTree();
 		git = new Git(repository);
 	}
 
@@ -114,7 +112,7 @@ public class GitActions implements AutoCloseable {
 
 	private String formatTagMessage(final String tagMessage) {
 		return formatCommitMessage(tagMessage)
-				.replace(GitCfg.TAG_MESSAGE_CHANGES, model.changes());
+				.replace(GitCfg.TAG_MESSAGE_CHANGES, model.changelog().lastReleasedChanges());
 	}
 
 	private String tagName() {

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
@@ -51,7 +51,7 @@ public class GitActions implements AutoCloseable {
 	private final ChangelogAndNext model;
 	private final GitCfg cfg;
 
-	public GitActions(File changelogFile, ChangelogAndNext model, GitCfg cfg) throws IOException {
+	GitActions(File changelogFile, ChangelogAndNext model, GitCfg cfg) throws IOException {
 		this.changelogFile = changelogFile;
 		this.model = model;
 		this.cfg = cfg;
@@ -98,7 +98,7 @@ public class GitActions implements AutoCloseable {
 
 	/** Tags and pushes the tag and the branch.  */
 	public void tagBranchPush() throws GitAPIException {
-		final TagCommand tagCommand = git.tag().setName(tagName());
+		TagCommand tagCommand = git.tag().setName(tagName());
 		if (cfg.useAnnotatedTag()) {
 			tagCommand.setAnnotated(true).setMessage(formatTagMessage(cfg.tagMessage()));
 		}

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
@@ -18,18 +18,18 @@ package com.diffplug.spotless.changelog;
 
 import java.io.File;
 import java.io.IOException;
+import org.eclipse.jgit.annotations.Nullable;
 
 /** Configuration for committing, tagging, and pushing the next version. */
 public class GitCfg {
 	public static final String COMMIT_MESSAGE_VERSION = "{{version}}";
 	public static final String TAG_MESSAGE_CHANGES = "{{changes}}";
-	public static final String NONE__USE_LIGHTWEIGHT_TAG = null;
 
 	/** Prefix used for release tags, default is `release/`. */
 	public String tagPrefix = "release/";
 	/** Message used for release commits, default is `Published release/{{version}}`. */
 	public String commitMessage = "Published release/" + COMMIT_MESSAGE_VERSION;
-	private String tagMessage = NONE__USE_LIGHTWEIGHT_TAG;
+	private String tagMessage = null;
 	public String remote = "origin";
 	public String branch = "main";
 	public String sshStrictHostKeyChecking = "yes";
@@ -48,7 +48,7 @@ public class GitCfg {
 	}
 
 	/** Sets the essage to annotate release tag: if null (the default), then a lightweight tag is created`. */
-	public void tagMessage(String tagMessage) {
+	public void tagMessage(@Nullable String tagMessage) {
 		this.tagMessage = tagMessage;
 	}
 
@@ -58,6 +58,6 @@ public class GitCfg {
 	}
 
 	public boolean useAnnotatedTag() {
-		return tagMessage != NONE__USE_LIGHTWEIGHT_TAG;
+		return tagMessage != null;
 	}
 }

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
@@ -18,7 +18,6 @@ package com.diffplug.spotless.changelog;
 
 import java.io.File;
 import java.io.IOException;
-import org.eclipse.jgit.annotations.Nullable;
 
 /** Configuration for committing, tagging, and pushing the next version. */
 public class GitCfg {
@@ -29,7 +28,8 @@ public class GitCfg {
 	public String tagPrefix = "release/";
 	/** Message used for release commits, default is `Published release/{{version}}`. */
 	public String commitMessage = "Published release/" + COMMIT_MESSAGE_VERSION;
-	private String tagMessage = null;
+	/** Message used in tag, null means lightweight tag. */
+	public String tagMessage = null;
 	public String remote = "origin";
 	public String branch = "main";
 	public String sshStrictHostKeyChecking = "yes";
@@ -45,19 +45,5 @@ public class GitCfg {
 			throw new IllegalArgumentException("The commit message must contain " + COMMIT_MESSAGE_VERSION + " to be replaced with the real version.");
 		}
 		return commitMessage;
-	}
-
-	/** Sets the essage to annotate release tag: if null (the default), then a lightweight tag is created`. */
-	public void tagMessage(@Nullable String tagMessage) {
-		this.tagMessage = tagMessage;
-	}
-
-	/** Gets the essage to annotate release tag: if null (the default), then a lightweight tag is created`. */
-	public String tagMessage() {
-		return tagMessage;
-	}
-
-	public boolean useAnnotatedTag() {
-		return tagMessage != null;
 	}
 }

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
@@ -27,6 +27,7 @@ public class GitCfg {
 	public String tagPrefix = "release/";
 	/** Message used for release commits, default is `Published release/{{version}}`. */
 	public String commitMessage = "Published release/" + COMMIT_MESSAGE_VERSION;
+	private String annotateMessage = "";
 	public String remote = "origin";
 	public String branch = "main";
 	public String sshStrictHostKeyChecking = "yes";
@@ -42,5 +43,15 @@ public class GitCfg {
 			throw new IllegalArgumentException("The commit message must contain " + COMMIT_MESSAGE_VERSION + " to be replaced with the real version.");
 		}
 		return commitMessage;
+	}
+
+	/** Sets the essage to annotate release tag: if empty (the default), then a lightweight tag is created`. */
+	public void annotateMessage(String annotateMessage) {
+		this.annotateMessage = annotateMessage;
+	}
+
+	/** Gets the essage to annotate release tag: if empty (the default), then a lightweight tag is created`. */
+	public String annotateMessage() {
+		return annotateMessage;
 	}
 }

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitCfg.java
@@ -22,12 +22,14 @@ import java.io.IOException;
 /** Configuration for committing, tagging, and pushing the next version. */
 public class GitCfg {
 	public static final String COMMIT_MESSAGE_VERSION = "{{version}}";
+	public static final String TAG_MESSAGE_CHANGES = "{{changes}}";
+	public static final String NONE__USE_LIGHTWEIGHT_TAG = null;
 
 	/** Prefix used for release tags, default is `release/`. */
 	public String tagPrefix = "release/";
 	/** Message used for release commits, default is `Published release/{{version}}`. */
 	public String commitMessage = "Published release/" + COMMIT_MESSAGE_VERSION;
-	private String annotateMessage = "";
+	private String tagMessage = NONE__USE_LIGHTWEIGHT_TAG;
 	public String remote = "origin";
 	public String branch = "main";
 	public String sshStrictHostKeyChecking = "yes";
@@ -45,13 +47,17 @@ public class GitCfg {
 		return commitMessage;
 	}
 
-	/** Sets the essage to annotate release tag: if empty (the default), then a lightweight tag is created`. */
-	public void annotateMessage(String annotateMessage) {
-		this.annotateMessage = annotateMessage;
+	/** Sets the essage to annotate release tag: if null (the default), then a lightweight tag is created`. */
+	public void tagMessage(String tagMessage) {
+		this.tagMessage = tagMessage;
 	}
 
-	/** Gets the essage to annotate release tag: if empty (the default), then a lightweight tag is created`. */
-	public String annotateMessage() {
-		return annotateMessage;
+	/** Gets the essage to annotate release tag: if null (the default), then a lightweight tag is created`. */
+	public String tagMessage() {
+		return tagMessage;
+	}
+
+	public boolean useAnnotatedTag() {
+		return tagMessage != NONE__USE_LIGHTWEIGHT_TAG;
 	}
 }

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -109,11 +109,6 @@ public class ChangelogExtension {
 		this.enforceCheck = enforceCheck;
 	}
 
-	/** Determines whether tags are lightweight (false) or annotated (true).  Default is false. */
-	public void annotateMessage(String tagMessage) {
-		gitCfg.tagMessage(tagMessage);
-	}
-
 	/**
 	 * Sets a custom {@link NextVersionFunction} by calling the public no-arg constructor of the given class.
 	 * Default value is {@link com.diffplug.spotless.changelog.NextVersionFunction.Semver Semver}.

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -196,7 +196,7 @@ public class ChangelogExtension {
 
 	/** Default value is null (creates a lightweight tag) - {{changes}} and {{version}} will be replaced. */
 	public void tagMessage(String tagMessage) {
-		gitCfg.tagMessage(tagMessage);
+		gitCfg.tagMessage = tagMessage;
 	}
 
 	/** Default value is 'origin' */

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -40,6 +40,7 @@ public class ChangelogExtension {
 	NextVersionCfg nextVersionCfg;
 	GitCfg gitCfg;
 	boolean enforceCheck;
+	boolean annotateTags = false;
 
 	public ChangelogExtension(Project project) {
 		this.project = Objects.requireNonNull(project);
@@ -107,6 +108,11 @@ public class ChangelogExtension {
 	/** Determines whether `changelogCheck` will be a dependency of `check`.  Default is true. */
 	public void enforceCheck(boolean enforceCheck) {
 		this.enforceCheck = enforceCheck;
+	}
+
+	/** Determines whether tags are lightweight (false) or annotated (true).  Default is false. */
+	public void annotateTags(boolean annotateTags) {
+		this.annotateTags = annotateTags;
 	}
 
 	/**

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -110,8 +110,8 @@ public class ChangelogExtension {
 	}
 
 	/** Determines whether tags are lightweight (false) or annotated (true).  Default is false. */
-	public void annotateMessage(String annotateMessage) {
-		gitCfg.annotateMessage(GitCfg.validateCommitMessage(annotateMessage));
+	public void annotateMessage(String tagMessage) {
+		gitCfg.tagMessage(tagMessage);
 	}
 
 	/**
@@ -197,6 +197,11 @@ public class ChangelogExtension {
 	/** Default value is `Published release/{{version}}` - the {{version}} will be replaced. */
 	public void commitMessage(String commitMessage) {
 		gitCfg.commitMessage = GitCfg.validateCommitMessage(commitMessage);
+	}
+
+	/** Default value is null (creates a lightweight tag) - {{changes}} and {{version}} will be replaced. */
+	public void tagMessage(String tagMessage) {
+		gitCfg.tagMessage(tagMessage);
 	}
 
 	/** Default value is 'origin' */

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -40,7 +40,6 @@ public class ChangelogExtension {
 	NextVersionCfg nextVersionCfg;
 	GitCfg gitCfg;
 	boolean enforceCheck;
-	boolean annotateTags = false;
 
 	public ChangelogExtension(Project project) {
 		this.project = Objects.requireNonNull(project);
@@ -111,8 +110,8 @@ public class ChangelogExtension {
 	}
 
 	/** Determines whether tags are lightweight (false) or annotated (true).  Default is false. */
-	public void annotateTags(boolean annotateTags) {
-		this.annotateTags = annotateTags;
+	public void annotateMessage(String annotateMessage) {
+		gitCfg.annotateMessage(GitCfg.validateCommitMessage(annotateMessage));
 	}
 
 	/**

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogPlugin.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogPlugin.java
@@ -181,7 +181,7 @@ public class ChangelogPlugin implements Plugin<Project> {
 			assertNotSnapshot();
 			GitActions git = extension.gitCfg.withChangelog(extension.changelogFile, extension.model());
 			git.addAndCommit();
-			git.tagBranchPush(extension.annotateTags);
+			git.tagBranchPush();
 		}
 	}
 }

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogPlugin.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogPlugin.java
@@ -181,7 +181,7 @@ public class ChangelogPlugin implements Plugin<Project> {
 			assertNotSnapshot();
 			GitActions git = extension.gitCfg.withChangelog(extension.changelogFile, extension.model());
 			git.addAndCommit();
-			git.tagBranchPush();
+			git.tagBranchPush(extension.annotateTags);
 		}
 	}
 }

--- a/spotless-changelog-plugin-gradle/src/test/java/com/diffplug/spotless/changelog/gradle/ChangelogPluginPushTest.java
+++ b/spotless-changelog-plugin-gradle/src/test/java/com/diffplug/spotless/changelog/gradle/ChangelogPluginPushTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019-2021 DiffPlug
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.diffplug.spotless.changelog.gradle;
+
+import static org.gradle.internal.impldep.org.junit.Assert.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.api.errors.GitAPIException;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestWatcher;
+import org.junit.runner.Description;
+
+public class ChangelogPluginPushTest extends GradleHarness {
+
+	@Rule
+	public DeleteOnSuccessTemporaryFolder temporaryFolder = new DeleteOnSuccessTemporaryFolder(new File("build"));
+	@Rule
+	public KeepTempFolderOnFailure keepTempFolderOnFailure = new KeepTempFolderOnFailure(temporaryFolder);
+
+	@Test
+	public void verifyAnnotatedTagMessage() throws IOException, GitAPIException {
+
+		final String testCaseFolder = "1.0.3-annotatedTag";
+		File origin = initUpstreamRepo(testCaseFolder);
+
+		final File working = temporaryFolder.newFolder("working");
+		Git git = Git.cloneRepository().setURI(origin.getAbsolutePath())
+				.setDirectory(working).call();
+
+		copyResourceFile(working, testCaseFolder, "CHANGELOG.md");
+
+		gradleRunner().withProjectDir(working)/*.withDebug(true)*/
+				.withArguments("changelogPush").build();
+
+		assertEquals("Version is 1.0.3, here are the changes:"
+				+ "\n\n### Fixed\n"
+				+ "- this should be in tag message\n",
+				annotatedTagMessage(git, "release/1.0.3"));
+	}
+
+	private String annotatedTagMessage(Git localGit, final String tagName) throws IOException {
+		return new RevWalk(localGit.getRepository()).parseTag(
+				localGit.getRepository().findRef(tagName).getObjectId())
+				.getFullMessage();
+	}
+
+	private File initUpstreamRepo(String testCaseFolder) throws IOException, GitAPIException {
+		File origin = temporaryFolder.newFolder("origin");
+		Git git = Git.init().setDirectory(origin).call();
+		copyResourceFile(origin, "settings.gradle");
+		copyResourceFile(origin, testCaseFolder, "build.gradle");
+		git.add().addFilepattern(".").call();
+		git.commit()
+				.setMessage("Commit all changes including additions")
+				.call();
+		return origin;
+	}
+
+	private void copyResourceFile(File working, String testCaseFolder, String fileName) throws IOException {
+		Files.copy(Paths.get("src/test/resources", testCaseFolder, fileName), working.toPath().resolve(fileName));
+	}
+
+	private void copyResourceFile(File working, String fileName) throws IOException {
+		Files.copy(Paths.get("src/test/resources", fileName), working.toPath().resolve(fileName));
+	}
+
+	static class KeepTempFolderOnFailure extends TestWatcher {
+		private final DeleteOnSuccessTemporaryFolder folder;
+
+		KeepTempFolderOnFailure(DeleteOnSuccessTemporaryFolder folder) {
+			this.folder = folder;
+		}
+
+		@Override
+		protected void failed(Throwable e, Description description) {
+			folder.disableDeletion();
+		}
+	}
+
+	static class DeleteOnSuccessTemporaryFolder extends TemporaryFolder {
+
+		boolean canDelete = true;
+
+		public DeleteOnSuccessTemporaryFolder(File file) {
+			super(file);
+		}
+
+		@Override
+		protected void after() {
+			if (canDelete)
+				super.after();
+		}
+
+		public void disableDeletion() {
+			canDelete = false;
+		}
+	}
+}

--- a/spotless-changelog-plugin-gradle/src/test/java/com/diffplug/spotless/changelog/gradle/ChangelogPluginPushTest.java
+++ b/spotless-changelog-plugin-gradle/src/test/java/com/diffplug/spotless/changelog/gradle/ChangelogPluginPushTest.java
@@ -15,7 +15,7 @@
  */
 package com.diffplug.spotless.changelog.gradle;
 
-import static org.gradle.internal.impldep.org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.File;
 import java.io.IOException;
@@ -59,9 +59,11 @@ public class ChangelogPluginPushTest extends GradleHarness {
 	}
 
 	private String annotatedTagMessage(Git localGit, final String tagName) throws IOException {
-		return new RevWalk(localGit.getRepository()).parseTag(
-				localGit.getRepository().findRef(tagName).getObjectId())
-				.getFullMessage();
+		try (RevWalk walk = new RevWalk(localGit.getRepository())) {
+			return walk.parseTag(
+					localGit.getRepository().findRef(tagName).getObjectId())
+					.getFullMessage();
+		}
 	}
 
 	private File initUpstreamRepo(String testCaseFolder) throws IOException, GitAPIException {

--- a/spotless-changelog-plugin-gradle/src/test/resources/1.0.3-annotatedTag/CHANGELOG.md
+++ b/spotless-changelog-plugin-gradle/src/test/resources/1.0.3-annotatedTag/CHANGELOG.md
@@ -5,7 +5,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.0.3] - 2021-04-23
-
 ### Fixed
 - this should be in tag message
+
+## [1.0.2] - 2021-04-23
+
+Initial release.

--- a/spotless-changelog-plugin-gradle/src/test/resources/1.0.3-annotatedTag/CHANGELOG.md
+++ b/spotless-changelog-plugin-gradle/src/test/resources/1.0.3-annotatedTag/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.3] - 2021-04-23
+
+### Fixed
+- this should be in tag message

--- a/spotless-changelog-plugin-gradle/src/test/resources/1.0.3-annotatedTag/build.gradle
+++ b/spotless-changelog-plugin-gradle/src/test/resources/1.0.3-annotatedTag/build.gradle
@@ -1,0 +1,8 @@
+plugins {
+    id 'com.diffplug.spotless-changelog'
+}
+
+spotlessChangelog {
+    branch 'master'
+    tagMessage 'Version is {{version}}, here are the changes:{{changes}}'
+}


### PR DESCRIPTION
In some cases it may be required to create annotated release tags, this PR adds this option to the Gradle extension.