### PR TITLE
`-Prelease=false` no longer generates an error.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `-Prelease=false` no longer generates an error (fixes [#28](https://github.com/diffplug/spotless-changelog/issues/28))
 
 ## [2.3.1] - 2021-11-10
 ### Fixed

--- a/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
+++ b/spotless-changelog-plugin-gradle/src/main/java/com/diffplug/spotless/changelog/gradle/ChangelogExtension.java
@@ -83,10 +83,13 @@ public class ChangelogExtension {
 								if ("true".equals(releaseValue)) {
 									cfgToUse = nextVersionCfg.shallowCopy();
 									cfgToUse.appendSnapshot = false;
+								} else if ("false".equals(releaseValue)) {
+									cfgToUse = nextVersionCfg;
 								} else {
-									throw new GradleException("spotless-changelog expects -Prelease to be either null or 'true', was '" + releaseValue + "'");
+									throw new GradleException("spotless-changelog expects -Prelease to be either null, 'true', or 'false` - this was '" + releaseValue + "'");
 								}
 							} catch (IllegalStateException e) {
+								// thrown on Prelease == null
 								cfgToUse = nextVersionCfg;
 							}
 							model = ChangelogAndNext.calculateUsingCache(changelogFile, cfgToUse);


### PR DESCRIPTION
Fixex #28