### PR TITLE
Bump to 11 and latest deps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Bump required Java from 8 to 11, and JGit from `5.13` to `6.4`. ([#43](https://github.com/diffplug/spotless-changelog/pull/43))
 
 ## [2.4.1] - 2022-11-24
 ### Fixed

--- a/build.gradle
+++ b/build.gradle
@@ -15,8 +15,8 @@ ext.javadoc_agg='spotless-changelog-lib spotless-changelog-plugin-gradle'
 apply from: 干.file('base/sonatype.gradle')
 
 String VER_JUNIT = '4.13.2'
-String VER_ASSERTJ = '3.23.1'
-String VER_JGIT= '5.13.1.202206130422-r'
+String VER_ASSERTJ = '3.24.2'
+String VER_JGIT= '6.4.0.202211300538-r'
 
 subprojects {
 	apply from: 干.file('base/java.gradle')
@@ -28,14 +28,14 @@ subprojects {
 		dependencies {
 			compileOnly 'pl.tlinkowski.annotation:pl.tlinkowski.annotation.basic:0.2.0'
 			testCompileOnly 'pl.tlinkowski.annotation:pl.tlinkowski.annotation.basic:0.2.0'
-			implementation 'org.osgi:org.osgi.framework:1.9.0'
+			implementation 'org.osgi:org.osgi.framework:1.10.0'
 			implementation 'com.diffplug.durian:durian-core:1.2.0'
 			implementation 'com.diffplug.durian:durian-collect:1.2.0'
 			implementation 'com.diffplug.durian:durian-io:1.2.0'
-			implementation "org.eclipse.jgit:org.eclipse.jgit:${VER_JGIT}"
-			implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:${VER_JGIT}"
-			testImplementation "junit:junit:${VER_JUNIT}"
-			testImplementation "org.assertj:assertj-core:${VER_ASSERTJ}"
+			implementation "org.eclipse.jgit:org.eclipse.jgit:$VER_JGIT"
+			implementation "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:$VER_JGIT"
+			testImplementation "junit:junit:$VER_JUNIT"
+			testImplementation "org.assertj:assertj-core:$VER_ASSERTJ"
 		}
 	} else {
 		assert it.name == 'spotless-changelog-plugin-gradle'
@@ -48,9 +48,9 @@ subprojects {
 			implementation 'com.diffplug.durian:durian-core:1.2.0'
 			implementation 'com.diffplug.durian:durian-collect:1.2.0'
 			implementation 'com.diffplug.durian:durian-io:1.2.0'
-			implementation "org.eclipse.jgit:org.eclipse.jgit:${VER_JGIT}"
-			testImplementation "junit:junit:${VER_JUNIT}"
-			testImplementation "org.assertj:assertj-core:${VER_ASSERTJ}"
+			implementation "org.eclipse.jgit:org.eclipse.jgit:$VER_JGIT"
+			testImplementation "junit:junit:$VER_JUNIT"
+			testImplementation "org.assertj:assertj-core:$VER_ASSERTJ"
 			// mock out the time
 			implementation 'com.diffplug.durian-globals:durian-globals:1.0.0'
 			// TODO: in Gradle 6.5 we could do this with a functionalTest sourceSet to keep it out of publishing

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ plugin_ifGitDiff_impl=com.diffplug.spotless.changelog.gradle.IfGitDiffPlugin
 plugin_ifGitDiff_name=If Git Diff
 plugin_ifGitDiff_desc=Decide what to configure based on changes relative to `origin/main`
 
-ver_java=8
+ver_java=11
 maven_group=com.diffplug.spotless-changelog
 javadoc_links=\
     https://docs.oracle.com/javase/8/docs/api/ \

--- a/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
+++ b/spotless-changelog-lib/src/main/java/com/diffplug/spotless/changelog/GitActions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019-2021 DiffPlug
+ * Copyright (C) 2019-2023 DiffPlug
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 package com.diffplug.spotless.changelog;
-
 
 import com.diffplug.common.collect.Iterables;
 import com.jcraft.jsch.Session;
@@ -35,13 +34,13 @@ import org.eclipse.jgit.lib.Ref;
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.eclipse.jgit.transport.CredentialsProvider;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig;
 import org.eclipse.jgit.transport.PushResult;
 import org.eclipse.jgit.transport.RefSpec;
 import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.transport.SshTransport;
 import org.eclipse.jgit.transport.UsernamePasswordCredentialsProvider;
+import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig;
 
 /** API for doing the commit, tag, and push operations.  See {@link GitCfg#withChangelog(File, ChangelogAndNext)}. */
 public class GitActions implements AutoCloseable {


### PR DESCRIPTION
Bump required Java from 8 to 11, and JGit from `5.13` to `6.4`.

I believe this will solve #41.